### PR TITLE
Support FORCE_COLOR environment variable

### DIFF
--- a/ansi.js
+++ b/ansi.js
@@ -32,6 +32,7 @@ const ansi = module.exports = {
 }
 
 const hasColor = _ =>
+	process.env.FORCE_COLOR ||
 	process.platform === "win32" ||
 	process.stdout.isTTY &&
 	process.env.TERM &&


### PR DESCRIPTION
Same as in [chalk](https://github.com/chalk/chalk#chalksupportscolor)

Useful in case of using [nodejs-dashboard](https://github.com/FormidableLabs/nodejs-dashboard/issues/15)